### PR TITLE
Move existing provisioning from envoy-build-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
-# ci-infra #
+# Envoy CI Infra #
 
-Configs and scripts that used to provisioning CI infrastructure for Envoy.
+This repo contains configs and scripts that used to provisioning CI infrastructure
+for Envoy.
+
+
+# Self-hosted AZP Agents #
+
+This contains all the code necessary for creating our Self-hosted AZP Agents.
+Right now this is done by creating AMI's with [Packer](https://www.packer.io/),
+and then standing up all of the Infrastructure with
+[Terraform](https://www.terraform.io/).
+
+The general idea is:
+
+  - AMIs are built with all necessary tooling, for Linux this includes:
+    - [`azure-pipelines-agent`](https://github.com/microsoft/azure-pipelines-agent),
+      `awscli` and `jq` for agent setup.
+    - `docker`
+    - [`bazel-remote`](https://github.com/buchgr/bazel-remote) for local S3 bazel cache proxy.
+
+  - AMIs are referenced by a launch template for an ASG.
+
+  - The ASG stands up a "minimum" number of idle instances to always be online to
+    work builds.
+
+  - When an agent started running a job, it detach itself from the ASG without
+    reducing desired number. A new idle runner will be spawn by the ASG.
+
+  - When an agent finishes the job, it terminates itself.
+
+  - A Lambda watches the EC2 CloudWatch instance termination event,
+   and properly deregisters the agent from AZP.

--- a/ami-build/README.md
+++ b/ami-build/README.md
@@ -1,0 +1,5 @@
+# AMI Build #
+
+This is a series of [Packer](https://www.packer.io/) scripts to build AMIs
+which will then launch inside of the ASG. In order to build these AMIs you
+will need access to the Envoy AWS Account.

--- a/ami-build/agent-setup.sh
+++ b/ami-build/agent-setup.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
+
+ARCH=$(dpkg --print-architecture)
+
+sudo apt-get update
+sudo apt-get -y upgrade
+sudo apt-get install -y apt-transport-https ca-certificates gnupg-agent software-properties-common wget
+
+wget -q -O - https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo apt-key adv --list-public-keys --with-fingerprint --with-colons 0EBFCD88 2>/dev/null | grep 'fpr' | head -n1 | grep '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+sudo add-apt-repository -y "deb [arch=${ARCH}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-add-repository -y ppa:git-core/ppa
+
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io git awscli jq inotify-tools
+
+sudo mkdir -p /etc/docker
+echo '{
+  "ipv6": true,
+  "fixed-cidr-v6": "2001:db8:1::/64"
+}' | sudo tee /etc/docker/daemon.json
+echo "::1 localhost" | sudo tee -a /etc/hosts
+
+sudo systemctl enable docker
+sudo systemctl start docker
+
+sudo useradd -ms /bin/bash -G docker azure-pipelines
+sudo mkdir -p /srv/azure-pipelines
+sudo chown -R azure-pipelines:azure-pipelines /srv/azure-pipelines/
+
+[[ "${ARCH}" == "amd64" ]] && ARCH=x64
+AGENT_VERSION=2.172.1
+AGENT_FILE=vsts-agent-linux-${ARCH}-${AGENT_VERSION}
+
+sudo -u azure-pipelines /bin/bash -c "wget -q -O - https://vstsagentpackage.azureedge.net/agent/${AGENT_VERSION}/${AGENT_FILE}.tar.gz | tar zx -C /srv/azure-pipelines"
+sudo /srv/azure-pipelines/bin/installdependencies.sh
+
+sudo -u azure-pipelines /bin/bash -c 'mkdir -p /home/azure-pipelines/.ssh && touch /home/azure-pipelines/.ssh/known_hosts'
+sudo -u azure-pipelines /bin/bash -c 'ssh-keyscan github.com | tee /home/azure-pipelines/.ssh/known_hosts'
+sudo -u azure-pipelines /bin/bash -c 'ssh-keygen -l -f /home/azure-pipelines/.ssh/known_hosts | grep github.com | grep "SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8"'
+
+sudo chown root:root /home/ubuntu/scripts/*.sh
+sudo chmod 0755 /home/ubuntu/scripts/*.sh
+sudo mv /home/ubuntu/scripts/*.sh /usr/local/bin
+
+sudo install-bazel-remote.sh
+sudo rm -rf /usr/local/bin/install-bazel-remote.sh
+sudo useradd -rms /bin/bash bazel-remote
+
+rm -rf /home/ubuntu/scripts /home/ubuntu/services

--- a/ami-build/azp-arm64.json
+++ b/ami-build/azp-arm64.json
@@ -1,0 +1,47 @@
+{
+  "variables": {},
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "region": "us-east-2",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "name": "ubuntu/images/*ubuntu-bionic-18.04-arm64-server-*",
+          "root-device-type": "ebs"
+        },
+        "owners": [
+          "099720109477"
+        ],
+        "most_recent": true
+      },
+      "instance_type": "r6g.large",
+      "ssh_username": "ubuntu",
+      "ami_name": "envoy-azp-arm64-{{timestamp}}",
+      "run_volume_tags": {
+        "Project": "Packer"
+      },
+      "run_tags": {
+        "Project": "Packer"
+      },
+      "tags": {
+        "Project": "envoy-azp-arm64"
+      },
+      "security_group_ids": [
+        "sg-030a7a75a086f208c"
+      ],
+      "encrypt_boot": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "scripts",
+      "destination": "/home/ubuntu/scripts"
+    },
+    {
+      "type": "shell",
+      "script": "agent-setup.sh"
+    }
+  ]
+}

--- a/ami-build/azp-x64.json
+++ b/ami-build/azp-x64.json
@@ -1,0 +1,47 @@
+{
+  "variables": {},
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "region": "us-east-2",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "name": "ubuntu/images/*ubuntu-bionic-18.04-amd64-server-*",
+          "root-device-type": "ebs"
+        },
+        "owners": [
+          "099720109477"
+        ],
+        "most_recent": true
+      },
+      "instance_type": "r5.large",
+      "ssh_username": "ubuntu",
+      "ami_name": "envoy-azp-x64-{{timestamp}}",
+      "run_volume_tags": {
+        "Project": "Packer"
+      },
+      "run_tags": {
+        "Project": "Packer"
+      },
+      "tags": {
+        "Project": "envoy-azp-x64"
+      },
+      "security_group_ids": [
+        "sg-030a7a75a086f208c"
+      ],
+      "encrypt_boot": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "scripts",
+      "destination": "/home/ubuntu/scripts"
+    },
+    {
+      "type": "shell",
+      "script": "agent-setup.sh"
+    }
+  ]
+}

--- a/ami-build/scripts/aws-metadata-refresh.sh
+++ b/ami-build/scripts/aws-metadata-refresh.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+mkdir -p /run/aws-metadata/
+
+role_name=$(wget -q -O - http://169.254.169.254/latest/meta-data/iam/security-credentials)
+wget -q -O - "http://169.254.169.254/latest/meta-data/iam/security-credentials/$role_name" > /run/aws-metadata/creds.json
+wget -q -O - http://169.254.169.254/latest/dynamic/instance-identity/document > /run/aws-metadata/iid.json
+
+chmod 0400 /run/aws-metadata/creds.json
+chmod 0400 /run/aws-metadata/iid.json
+chmod 0400 /run/aws-metadata/asg-name
+chown azure-pipelines:azure-pipelines /run/aws-metadata/creds.json
+chown azure-pipelines:azure-pipelines /run/aws-metadata/iid.json
+chown azure-pipelines:azure-pipelines /run/aws-metadata/asg-name

--- a/ami-build/scripts/detach-self.sh
+++ b/ami-build/scripts/detach-self.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# Check Pre-Reqs, and that we're running on an AWS Instance Seemingly.
+if ! hash aws >/dev/null 2>&1 ; then
+  echo "Need the AWS Cli in order to set AWS Protection."
+  exit 1
+fi
+if ! hash jq >/dev/null 2>&1 ; then
+  echo "Need JQ in order to query credentials."
+  exit 2
+fi
+if [[ ! -f "/sys/devices/virtual/dmi/id/board_asset_tag" ]]; then
+  echo "Doesn't seem to be an AWS Instance: [/sys/devices/virtual/dmi/id/board_asset_tag] does not exist".
+  exit 3
+fi
+instance_id=$(< /sys/devices/virtual/dmi/id/board_asset_tag)
+if [[ ! "$instance_id" =~ ^i- ]]; then
+  echo "Retrieved Instance ID: [$instance_id] does not start with [i-]"
+  exit 4
+fi
+
+function ensureCredentials() {
+  if [[ ! -f "/run/aws-metadata/creds.json" ]] || [[ ! -f "/run/aws-metadata/asg-name" ]] || [[ ! -f "/run/aws-metadata/iid.json" ]] || \
+     [[ ! -r "/run/aws-metadata/creds.json" ]] || [[ ! -r "/run/aws-metadata/asg-name" ]] || [[ ! -r "/run/aws-metadata/iid.json" ]]; then
+    echo "Failed to find Credentials for AWS Instance."
+    exit 5
+  fi
+
+  local readonly credentials_json=$(< /run/aws-metadata/creds.json)
+  local readonly iid_json=$(< /run/aws-metadata/iid.json)
+  local readonly asg_name=$(< /run/aws-metadata/asg-name)
+  local readonly aws_access_key=$(echo -n "$credentials_json" | jq -r .AccessKeyId)
+  local readonly secret_access_key=$(echo -n "$credentials_json" | jq -r .SecretAccessKey)
+  local readonly session_token=$(echo -n "$credentials_json" | jq -r .Token)
+  local readonly expiration=$(echo -n "$credentials_json" | jq -r .Expiration)
+  local readonly region=$(echo -n "$iid_json" | jq -r .region)
+
+  echo "Fetched Cached Credentials, Expire At: [$expiration]"
+  export AWS_ACCESS_KEY_ID="$aws_access_key"
+  export AWS_SECRET_ACCESS_KEY="$secret_access_key"
+  export AWS_SESSION_TOKEN="$session_token"
+  export AWS_DEFAULT_REGION="$region"
+  export CURRENT_ASG_NAME="$asg_name"
+}
+
+ensureCredentials
+aws autoscaling detach-instances --instance-ids "$instance_id" --auto-scaling-group-name "$CURRENT_ASG_NAME" --no-should-decrement-desired-capacity

--- a/ami-build/scripts/install-bazel-remote.sh
+++ b/ami-build/scripts/install-bazel-remote.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+export GOARCH=$(dpkg --print-architecture)
+
+BUILD_TMP="$(mktemp -d)"
+trap "chmod +w -R ${BUILD_TMP} && rm -rf ${BUILD_TMP}" EXIT
+
+cd "${BUILD_TMP}"
+
+curl -fsSL https://golang.org/dl/go1.14.5.linux-${GOARCH}.tar.gz | tar zx
+export GOPATH="${BUILD_TMP}/gopath"
+
+git clone https://github.com/buchgr/bazel-remote
+cd bazel-remote
+PATH="${BUILD_TMP}/go/bin:${PATH}" ./linux-build.sh
+sudo cp ./bazel-remote /usr/local/bin/bazel-remote

--- a/ami-build/services/aws-metadata-refresh.service
+++ b/ami-build/services/aws-metadata-refresh.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Refersh User Data Credentials for AZP
+Wants=aws-metadata-refresh.timer
+
+[Service]
+ExecStart=/usr/local/bin/aws-metadata-refresh.sh
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/ami-build/services/aws-metadata-refresh.timer
+++ b/ami-build/services/aws-metadata-refresh.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Renew AWS Creds once every half hour
+Requires=aws-metadata-refresh.service
+
+[Timer]
+Unit=aws-metadata-refresh.service
+OnUnitInactiveSec=30m
+RandomizedDelaySec=30m
+
+[Install]
+WantedBy=timers.target

--- a/instances/.gitignore
+++ b/instances/.gitignore
@@ -1,0 +1,3 @@
+/.terraform
+/lambda-dereg.zip
+/lambda-cleanup.zip

--- a/instances/azp-build-asg/iam.tf
+++ b/instances/azp-build-asg/iam.tf
@@ -1,0 +1,130 @@
+# Creates an IAM Role where instances themselves can then detach themselves from ASG.
+data "aws_iam_policy_document" "asg_detach_instances" {
+  statement {
+    actions = [
+      "autoscaling:DetachInstances"
+    ]
+
+    resources = [
+      "arn:aws:autoscaling:*:${var.aws_account_id}:autoScalingGroup:*:autoScalingGroupName/${local.asg_name}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bazel_cache_bucket}",
+    ]
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "${var.cache_prefix}/*",
+      ]
+    }
+  }
+  statement {
+    actions = [
+      "s3:*Object"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bazel_cache_bucket}/${var.cache_prefix}/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "instance_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "asg_iam_role" {
+  name               = "${var.ami_prefix}_${var.azp_pool_name}_IAMRole"
+  assume_role_policy = data.aws_iam_policy_document.instance_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy" "asg_iam_role_policy" {
+  name   = "${var.ami_prefix}_${var.azp_pool_name}_IAMRolePolicy"
+  role   = aws_iam_role.asg_iam_role.id
+  policy = data.aws_iam_policy_document.asg_detach_instances.json
+}
+
+resource "aws_iam_instance_profile" "asg_iam_instance_profile" {
+  name = "${var.ami_prefix}_${var.azp_pool_name}_IProfile"
+  role = aws_iam_role.asg_iam_role.name
+}
+
+# Creates an IAM Role where instances can get token and associate with running IAM profile.
+data "aws_iam_policy_document" "init_permissions" {
+  statement {
+    actions = [
+      "s3:GetObject"
+    ]
+
+    resources = [
+      "arn:aws:s3:::cncf-envoy-token/azp_token",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ec2:ReplaceIamInstanceProfileAssociation"
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ARN"
+      values   = ["$${ec2:SourceInstanceARN}"]
+    }
+  }
+
+  statement {
+    actions = [
+      "iam:PassRole"
+    ]
+
+    resources = [
+      aws_iam_role.asg_iam_role.arn
+    ]
+  }
+
+  statement {
+    actions = [
+      "ec2:DescribeIamInstanceProfileAssociations"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+}
+
+resource "aws_iam_role" "asg_init_iam_role" {
+  name               = "${var.ami_prefix}_${var.azp_pool_name}_init_IAMRole"
+  assume_role_policy = data.aws_iam_policy_document.instance_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy" "asg_init_iam_role_policy" {
+  name   = "${var.ami_prefix}_${var.azp_pool_name}_init_IAMRolePolicy"
+  role   = aws_iam_role.asg_init_iam_role.id
+  policy = data.aws_iam_policy_document.init_permissions.json
+}
+
+resource "aws_iam_instance_profile" "asg_init_iam_instance_profile" {
+  name = "${var.ami_prefix}_${var.azp_pool_name}_init_IProfile"
+  role = aws_iam_role.asg_init_iam_role.name
+}

--- a/instances/azp-build-asg/init.sh.tpl
+++ b/instances/azp-build-asg/init.sh.tpl
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -e
+
+function terminate {
+    # Terminate instances in 1 min
+    shutdown -h +1
+}
+trap terminate EXIT
+
+# Hostname shows in AZP side, use Instance ID Rather than a public ip.
+instance_id=$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)
+echo "127.0.1.1 $instance_id" >> /etc/hosts
+hostnamectl set-hostname "$instance_id"
+
+azp_token=$(aws s3 cp s3://cncf-envoy-token/azp_token -)
+
+export AWS_DEFAULT_REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
+aws ec2 replace-iam-instance-profile-association --iam-instance-profile Arn=${instance_profile_arn} \
+  --association-id $(aws ec2 describe-iam-instance-profile-associations --filter=Name=instance-id,Values=$instance_id | jq -r '.IamInstanceProfileAssociations[0].AssociationId')
+
+# Configure Azure Pipelines Agent, this has to be done at runtime since
+# it will show up in the UI once we configure.
+sudo -u azure-pipelines /bin/bash -c "cd /srv/azure-pipelines && ./config.sh --unattended --acceptteeeula --url https://dev.azure.com/cncf/ --pool ${azp_pool_name} --token $azp_token"
+sudo -u azure-pipelines mkdir /srv/azure-pipelines/_work
+
+# Clear credential cache and verify we're in right role before starting agent
+unset azp_token
+rm -rf ~/.aws
+aws sts get-caller-identity | jq -r '.Arn' | grep -o "/${role_name}/"
+
+# Setup bazel remote cache S3 proxy
+echo "
+[Unit]
+Description=Bazel Remote Cache Service
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+User=bazel-remote
+ExecStart=/usr/local/bin/bazel-remote --s3.endpoint s3.$AWS_DEFAULT_REGION.amazonaws.com --s3.bucket ${bazel_cache_bucket} --s3.prefix ${cache_prefix} --s3.iam_role_endpoint http://169.254.169.254 --max_size 30 --dir /dev/shm/bazel-remote-cache
+
+[Install]
+WantedBy=multi-user.target
+" > /etc/systemd/system/bazel-remote.service
+
+systemctl daemon-reload
+systemctl enable bazel-remote
+systemctl start bazel-remote
+
+# This is a hook to be run when a job starts
+(inotifywait /srv/azure-pipelines/_work -e CREATE && aws autoscaling detach-instances --instance-ids $instance_id --auto-scaling-group-name ${asg_name} --no-should-decrement-desired-capacity || true) &
+
+# Start AZP Agent.
+sudo -u azure-pipelines /bin/bash -c 'cd /srv/azure-pipelines && ./run.sh --once'

--- a/instances/azp-build-asg/inputs.tf
+++ b/instances/azp-build-asg/inputs.tf
@@ -1,0 +1,13 @@
+variable "ami_prefix" { type = string }
+variable "aws_account_id" { type = string }
+variable "azp_pool_name" { type = string }
+variable "azp_token" { type = string }
+variable "disk_size_gb" { type = number }
+variable "on_demand_instances_count" {
+  type    = number
+  default = 0
+}
+variable "idle_instances_count" { type = number }
+variable "instance_type" { type = string }
+variable "bazel_cache_bucket" { type = string }
+variable "cache_prefix" { type = string }

--- a/instances/azp-build-asg/instances.tf
+++ b/instances/azp-build-asg/instances.tf
@@ -1,0 +1,110 @@
+locals {
+  asg_name = "${var.ami_prefix}_${var.azp_pool_name}_pool"
+}
+
+data "aws_ami" "azp_ci_image" {
+  most_recent = true
+  owners      = [var.aws_account_id]
+
+  filter {
+    name   = "name"
+    values = ["${var.ami_prefix}-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+data "template_file" "init" {
+  template = file("${path.module}/init.sh.tpl")
+  vars = {
+    asg_name             = local.asg_name
+    azp_pool_name        = var.azp_pool_name
+    instance_profile_arn = aws_iam_instance_profile.asg_iam_instance_profile.arn
+    role_name            = aws_iam_role.asg_iam_role.name
+    bazel_cache_bucket   = var.bazel_cache_bucket
+    cache_prefix         = var.cache_prefix
+  }
+}
+
+resource "aws_placement_group" "spread" {
+  name     = "${var.ami_prefix}_${var.azp_pool_name}_placement_group"
+  strategy = "spread"
+}
+
+resource "aws_launch_template" "build_pool" {
+  name_prefix   = "${var.ami_prefix}_${var.azp_pool_name}"
+  image_id      = data.aws_ami.azp_ci_image.id
+  instance_type = var.instance_type
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+
+    ebs {
+      volume_size           = var.disk_size_gb
+      volume_type           = "gp2"
+      delete_on_termination = true
+      encrypted             = true
+    }
+  }
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.asg_init_iam_instance_profile.arn
+  }
+
+  monitoring {
+    enabled = true
+  }
+
+  instance_initiated_shutdown_behavior = "terminate"
+  key_name                             = "envoy-shared"
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "optional"
+  }
+  user_data              = base64encode(data.template_file.init.rendered)
+  vpc_security_group_ids = [aws_security_group.allow_ssh.id]
+}
+
+resource "aws_autoscaling_group" "build_pool" {
+  name            = local.asg_name
+  placement_group = aws_placement_group.spread.id
+
+  min_size         = var.idle_instances_count
+  desired_capacity = var.idle_instances_count
+  max_size         = 50
+
+  health_check_grace_period = 300
+  health_check_type         = "EC2"
+
+  mixed_instances_policy {
+    launch_template {
+      launch_template_specification {
+        launch_template_id = aws_launch_template.build_pool.id
+        version            = "$Latest"
+      }
+
+      override {
+        instance_type = var.instance_type
+      }
+    }
+
+    instances_distribution {
+      on_demand_base_capacity                  = var.on_demand_instances_count
+      on_demand_percentage_above_base_capacity = 0
+      spot_allocation_strategy                 = "capacity-optimized"
+    }
+  }
+
+  tags = [
+    {
+      key                 = "PoolName"
+      value               = var.azp_pool_name
+      propagate_at_launch = true
+    }
+  ]
+
+  vpc_zone_identifier = data.aws_subnet_ids.default.ids
+}

--- a/instances/azp-build-asg/main.tf
+++ b/instances/azp-build-asg/main.tf
@@ -1,0 +1,1 @@
+provider "aws" {}

--- a/instances/azp-build-asg/vpc.tf
+++ b/instances/azp-build-asg/vpc.tf
@@ -1,0 +1,37 @@
+resource "aws_default_vpc" "default" {
+}
+
+data "aws_subnet_ids" "default" {
+  vpc_id = aws_default_vpc.default.id
+
+  filter {
+    name = "availability-zone-id"
+
+    # The ones with r6g.* availability.
+    values = [
+      "use2-az2",
+      "use2-az3",
+    ]
+  }
+}
+
+resource "aws_security_group" "allow_ssh" {
+  name        = "allow_ssh_${local.asg_name}"
+  description = "Allow SSH inbound traffic"
+  vpc_id      = aws_default_vpc.default.id
+
+  ingress {
+    description = "SSH from World"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/instances/azp-cleanup-snapshots/.gitignore
+++ b/instances/azp-cleanup-snapshots/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/instances/azp-cleanup-snapshots/README.md
+++ b/instances/azp-cleanup-snapshots/README.md
@@ -1,0 +1,8 @@
+# AZP Cleanup Snapshots #
+
+By default our AMI Building Tool "Packer", leaves around snapshots indefinitely
+along with the AMIs it builds. The goal of this lambda is to run every day,
+find any AMIs that aren't used, as well as snapshots, and delete them.
+
+This is just a cost savings measure even though snapshots are relatively cheap
+there is no reason to be paying for them.

--- a/instances/azp-cleanup-snapshots/index.js
+++ b/instances/azp-cleanup-snapshots/index.js
@@ -1,0 +1,235 @@
+const AWS = require('aws-sdk');
+const ec2 = new AWS.EC2();
+
+async function describeAmis() {
+  return await new Promise((resolve, reject) => {
+    ec2.describeImages(
+      {
+        Filters: [
+          {
+            Name: 'image-type',
+            Values: ['machine'],
+          },
+          {
+            Name: 'owner-id',
+            Values: ['457956385456'],
+          },
+          {
+            Name: 'state',
+            Values: ['available'],
+          },
+        ],
+      },
+      (err, data) => {
+        if (err != null) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      },
+    );
+  });
+}
+
+function extractLatestTemplateFromList(launchTemplates) {
+  return launchTemplates
+    .sort((comp, compTwo) => {
+      if (comp.VersionNumber < compTwo.VersionNumber) {
+        return -1;
+      } else if (comp.VersionNumber > compTwo.VersionNumber) {
+        return 1;
+      } else {
+        return 0;
+      }
+    })
+    .slice(-1)[0];
+}
+
+async function latestLTVersionTailRec(launchTemplateId, nextToken = null) {
+  const data = await new Promise((resolve, reject) => {
+    ec2.describeLaunchTemplateVersions(
+      {
+        LaunchTemplateId: launchTemplateId,
+        NextToken: nextToken == null ? undefined : nextToken,
+      },
+      (err, data) => {
+        if (err != null) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      },
+    );
+  });
+
+  if (data.NextToken != null && data.NextToken != '') {
+    return await latestLTVersionTailRec(launchTemplateId, data.NextToken);
+  } else {
+    return extractLatestTemplateFromList(data.LaunchTemplateVersions);
+  }
+}
+
+/**
+ * Determine if an AMI is the latest in a launch template.
+ *
+ * @param {String} imageId
+ *  The AMI ID to check on.
+ */
+async function amiIsUsedLatestTemplate(imageId) {
+  const launchTemplates = await new Promise((resolve, reject) => {
+    ec2.describeLaunchTemplates({}, (err, data) => {
+      if (err != null) {
+        reject(err);
+      } else {
+        resolve(data);
+      }
+    });
+  });
+
+  let isUsed = false;
+  let seenTemplates = [];
+  for (let template of launchTemplates.LaunchTemplates) {
+    if (seenTemplates.indexOf(template.LaunchTemplateId) == -1) {
+      let latestVersion = await latestLTVersionTailRec(
+        template.LaunchTemplateId,
+      );
+      if (latestVersion['LaunchTemplateData']['ImageId'] == imageId) {
+        isUsed = true;
+        return isUsed;
+      }
+      seenTemplates.push(template.LaunchTemplateId);
+    }
+  }
+  return isUsed;
+}
+
+/**
+ * Determine if an AMI is being used by an EC2 instance actively.
+ *
+ * @param {String} imageId
+ *  The AMI ID to check on.
+ */
+async function amiIsUsedInstance(imageId) {
+  const instances = await new Promise((resolve, reject) => {
+    ec2.describeInstances(
+      {
+        DryRun: false,
+        Filters: [
+          {
+            Name: 'image-id',
+            Values: [imageId],
+          },
+        ],
+        // We only need to know if 1 is in used, but the minimum is 5.
+        MaxResults: 5,
+      },
+      (err, data) => {
+        if (err != null) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      },
+    );
+  });
+
+  return instances['Reservations'] != null && instances.Reservations.length > 0;
+}
+
+exports.handler = async function (_, context) {
+  try {
+    const amiResp = await describeAmis();
+
+    // Find all AZP AMIs.
+    const azpAmis = amiResp.Images.filter((image) => {
+      if (image['Tags'] == null) {
+        return false;
+      }
+
+      let has_envoy_project_tag = false;
+      image['Tags'].forEach((tagObj) => {
+        if (tagObj['Key'] != 'Project') {
+          return;
+        }
+        if (tagObj['Value'].indexOf('envoy-azp-') != 0) {
+          return;
+        }
+        has_envoy_project_tag = true;
+      });
+
+      return has_envoy_project_tag;
+    });
+
+    // Find all unused AZP AMIs.
+    let defunctAmis = [];
+    for (let amiObj of azpAmis) {
+      const amiID = amiObj.ImageId;
+
+      const isUsedInstance = await amiIsUsedInstance(amiID);
+      if (isUsedInstance) {
+        console.log('Found AMI being used by instances:', amiID);
+        continue;
+      }
+      const isUsedTemplates = await amiIsUsedLatestTemplate(amiID);
+      if (isUsedTemplates) {
+        console.log('Found AMI being used in the latest template:', amiID);
+        continue;
+      }
+
+      defunctAmis.push(amiObj);
+    }
+
+    // Delete AMIs + Snapshots.
+    for (let amiObj of defunctAmis) {
+      console.log('Found Defunct AMI: ', amiObj.ImageId);
+      const amiID = amiObj.ImageId;
+      const snapshotIDs = amiObj.BlockDeviceMappings.filter(
+        (bdm) => bdm['Ebs'] != null && bdm['Ebs']['SnapshotId'] != null,
+      ).map((bdm) => bdm.Ebs.SnapshotId);
+      console.log(
+        'Deleting AMI: ',
+        amiID,
+        ' and associated snapshot IDs: ',
+        snapshotIDs,
+      );
+
+      // Deregister the image.
+      await new Promise((resolve, reject) => {
+        ec2.deregisterImage(
+          {
+            ImageId: amiID,
+          },
+          (err) => {
+            if (err != null) {
+              reject(err);
+            } else {
+              resolve();
+            }
+          },
+        );
+      });
+
+      for (let snapshotID of snapshotIDs) {
+        await new Promise((resolve, reject) => {
+          ec2.deleteSnapshot(
+            {
+              SnapshotId: snapshotID,
+            },
+            (err) => {
+              if (err != null) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            },
+          );
+        });
+      }
+    }
+
+    context.succeed();
+  } catch (error) {
+    console.log('Failed to Cleanup AMIs: ', error, error.stack);
+    context.fail();
+  }
+};

--- a/instances/azp-cleanup-snapshots/package-lock.json
+++ b/instances/azp-cleanup-snapshots/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "azp-cleanup-snapshots",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
+    }
+  }
+}

--- a/instances/azp-cleanup-snapshots/package.json
+++ b/instances/azp-cleanup-snapshots/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "azp-cleanup-snapshots",
+  "version": "1.0.0",
+  "description": "An Lambda that cleans up snapshots within AWS that were built for AZP.",
+  "main": "index.js",
+  "scripts": {
+    "format": "prettier --single-quote --trailing-comma all --write '*.js'",
+    "lint": "prettier --single-quote --trailing-comma all --check '*.js'",
+    "build": "rm -rf ./node_modules/ && npm install --production && zip -r ../lambda-cleanup.zip ."
+  },
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "prettier": "^2.0.5"
+  }
+}

--- a/instances/azp-dereg-lambda/.gitignore
+++ b/instances/azp-dereg-lambda/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/instances/azp-dereg-lambda/README.md
+++ b/instances/azp-dereg-lambda/README.md
@@ -1,0 +1,8 @@
+# AZP Deregistration Lambda
+
+A lambda function that listens for instances being destroyed, and properly
+deregisters them from Azure Pipelines, so they don't clutter up the UI, or
+potentially try to schedule on nodes that are no longer running.
+
+This uses ASG Lifecycle Hooks, published to an SNS Queue in order to know
+when an instance has been destroyed.

--- a/instances/azp-dereg-lambda/index.js
+++ b/instances/azp-dereg-lambda/index.js
@@ -1,0 +1,77 @@
+const axios = require('axios');
+const AWS = require('aws-sdk');
+const ec2 = new AWS.EC2();
+
+const AZP_USER = process.env['AZP_USER'];
+const AZP_TOKEN = process.env['AZP_TOKEN'];
+
+exports.handler = async function (notification, context) {
+  const instanceId = notification["detail"]["instance-id"];
+
+  try {
+    // Extract the Azure Pool Name from the Instances Tags.
+    const data = await new Promise((resolve, reject) => {
+      ec2.describeInstances({ InstanceIds: [instanceId] }, function (
+        err,
+        data,
+      ) {
+        if (err != null) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      });
+    });
+    const instance = data['Reservations'][0]['Instances'][0];
+    const azpPoolName = instance['Tags'].filter((value) => {
+      return value['Key'] == 'PoolName';
+    })[0]['Value'];
+
+    // Next turn the Azure Pool Name into an Azure Pool ID.
+    const azpPoolResp = await axios.get(
+      `https://dev.azure.com/cncf/_apis/distributedtask/pools?poolName=${azpPoolName}&api-version=5.1`,
+      {
+        auth: {
+          username: AZP_USER,
+          password: AZP_TOKEN,
+        },
+      },
+    );
+    if (azpPoolResp['data'] == null) {
+      console.log('Failed to call AZP Resp: ', azpPoolResp);
+    }
+    const azpPoolId = azpPoolResp['data']['value'][0]['id'];
+
+    // Finally turn the AZP Agent Name to an ID.
+    const azpAgentPool = await axios.get(
+      `https://dev.azure.com/cncf/_apis/distributedtask/pools/${azpPoolId}/agents?agentName=${instanceId}&api-version=5.1`,
+      {
+        auth: {
+          username: AZP_USER,
+          password: AZP_TOKEN,
+        },
+      },
+    );
+    if (azpAgentPool['data'] == null) {
+      console.log('Failed to call AZP Agent Pool: ', azpAgentPool);
+    }
+    const azpAgentId = azpAgentPool['data']['value'][0]['id'];
+
+    // Deregister the instance from the pool for Azure.
+    await axios.delete(
+      `https://dev.azure.com/cncf/_apis/distributedtask/pools/${azpPoolId}/agents/${azpAgentId}?api-version=5.1`,
+      {
+        auth: {
+          username: AZP_USER,
+          password: AZP_TOKEN,
+        },
+      },
+    );
+
+    context.succeed();
+  } catch (error) {
+    console.log('Failed to deregister instance: ', instanceId);
+    console.log('Caught Error: ', error);
+    context.fail();
+  }
+};

--- a/instances/azp-dereg-lambda/package-lock.json
+++ b/instances/azp-dereg-lambda/package-lock.json
@@ -1,0 +1,43 @@
+{
+  "name": "azp-dereg-lambda",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
+    }
+  }
+}

--- a/instances/azp-dereg-lambda/package.json
+++ b/instances/azp-dereg-lambda/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "azp-dereg-lambda",
+  "version": "1.0.0",
+  "description": "A lambda function that listens for instances being destroyed, and properly deregisters them from Azure Pipelines.",
+  "main": "index.js",
+  "scripts": {
+    "format": "prettier --single-quote --trailing-comma all --write '*.js'",
+    "lint": "prettier --single-quote --trailing-comma all --check '*.js'",
+    "build": "rm -rf ./node_modules/ && npm install --production && zip -r ../lambda-dereg.zip ."
+  },
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.19.2"
+  },
+  "devDependencies": {
+    "prettier": "^2.0.5"
+  }
+}

--- a/instances/cloudwatch.tf
+++ b/instances/cloudwatch.tf
@@ -1,0 +1,54 @@
+resource "aws_cloudwatch_event_rule" "every_day" {
+  name                = "every-day"
+  description         = "Fires once every day"
+  schedule_expression = "rate(1 day)"
+}
+
+resource "aws_cloudwatch_event_target" "cleanup_every_day" {
+  rule      = aws_cloudwatch_event_rule.every_day.name
+  target_id = "cleanup_amis_daily"
+  arn       = aws_lambda_function.cleanup_lambda.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_cleanup" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.cleanup_lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.every_day.arn
+}
+
+resource "aws_cloudwatch_event_rule" "ec2_terminate" {
+  name        = "ec2-terminate"
+  description = "EC2 instance terminate"
+
+  event_pattern = <<PATTERN
+{
+  "source": [
+    "aws.ec2"
+  ],
+  "detail-type": [
+    "EC2 Instance State-change Notification"
+  ],
+  "detail": {
+    "state": [
+      "terminated"
+    ]
+  }
+}
+PATTERN
+}
+
+resource "aws_cloudwatch_event_target" "ec2_terminate_dereg" {
+  rule      = aws_cloudwatch_event_rule.ec2_terminate.name
+  target_id = "azp_dereg_lambda"
+  arn       = aws_lambda_function.dereg_lambda.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_dereg" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.dereg_lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.ec2_terminate.arn
+}

--- a/instances/iam.tf
+++ b/instances/iam.tf
@@ -1,0 +1,95 @@
+#########################################################################################
+# Permissions for the Lambda to Deregister Instances.                                   #
+#########################################################################################
+
+data "aws_iam_policy_document" "lambda_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "lambda_logs" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["arn:aws:logs:*:*:*"]
+  }
+}
+
+data "aws_iam_policy_document" "lambda_ec2_permissions" {
+  statement {
+    actions = [
+      # Get the Tags to identify the Pool Name.
+      "ec2:DescribeInstances",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "lambda_role" {
+  name               = "azp_dereg_lambda_role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy" "log_perms" {
+  name = "azp_dereg_lambda_log_perms"
+  role = aws_iam_role.lambda_role.id
+
+  policy = data.aws_iam_policy_document.lambda_logs.json
+}
+
+resource "aws_iam_role_policy" "ec2_perms" {
+  name = "azp_dereg_lambda_ec2_perms"
+  role = aws_iam_role.lambda_role.id
+
+  policy = data.aws_iam_policy_document.lambda_ec2_permissions.json
+}
+
+#########################################################################################
+# Permissions for the Cleanup Lambda.                                                   #
+#########################################################################################
+
+data "aws_iam_policy_document" "lambda_cleanup_ami_permissions" {
+  statement {
+    actions = [
+      # Allow it to describe things in EC2 to not only describe the AMIs
+      # but also find all places they're being used.
+      "ec2:Describe*",
+      # Allow it to deregister an AMI so it can't be used anymore.
+      "ec2:DeregisterImage",
+      # Allow it to delete the snapshot of the AMI.
+      "ec2:DeleteSnapshot",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "cleanup_lambda_role" {
+  name               = "cleanup_lambda_role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy" "log_perms_cleanup" {
+  name = "cleanup_lambda_log_perms"
+  role = aws_iam_role.cleanup_lambda_role.id
+
+  policy = data.aws_iam_policy_document.lambda_logs.json
+}
+
+resource "aws_iam_role_policy" "cleanup_ec2_perms" {
+  name = "cleanup_lambda_ec2_perms"
+  role = aws_iam_role.cleanup_lambda_role.id
+
+  policy = data.aws_iam_policy_document.lambda_cleanup_ami_permissions.json
+}

--- a/instances/input.tf
+++ b/instances/input.tf
@@ -1,0 +1,1 @@
+variable "azp_token" { type = string }

--- a/instances/lambda.tf
+++ b/instances/lambda.tf
@@ -1,0 +1,32 @@
+resource "aws_lambda_function" "dereg_lambda" {
+  filename      = "lambda-dereg.zip"
+  function_name = "azp_dereg_lambda"
+  role          = aws_iam_role.lambda_role.arn
+  handler       = "index.handler"
+  runtime       = "nodejs12.x"
+
+  memory_size = 512
+  timeout     = 180
+
+  source_code_hash = filebase64sha256("lambda-dereg.zip")
+
+  environment {
+    variables = {
+      AZP_USER  = "cncf"
+      AZP_TOKEN = var.azp_token
+    }
+  }
+}
+
+resource "aws_lambda_function" "cleanup_lambda" {
+  filename      = "lambda-cleanup.zip"
+  function_name = "ami_cleanup_lambda"
+  role          = aws_iam_role.cleanup_lambda_role.arn
+  handler       = "index.handler"
+  runtime       = "nodejs12.x"
+
+  memory_size = 512
+  timeout     = 180
+
+  source_code_hash = filebase64sha256("lambda-cleanup.zip")
+}

--- a/instances/main.tf
+++ b/instances/main.tf
@@ -1,0 +1,46 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = "us-east-2"
+}
+
+provider "aws" {
+  alias   = "us-east-1"
+  version = "~> 2.0"
+  region  = "us-east-1"
+}
+
+module "x64-large-build-pool" {
+  source = "./azp-build-asg"
+
+  ami_prefix           = "envoy-azp-x64"
+  aws_account_id       = "457956385456"
+  azp_pool_name        = "x64-large"
+  azp_token            = var.azp_token
+  disk_size_gb         = 2000
+  idle_instances_count = 1
+  instance_type        = "r5.8xlarge"
+  bazel_cache_bucket   = aws_s3_bucket.build-cache.bucket
+  cache_prefix         = "public-x64"
+
+  providers = {
+    aws = aws
+  }
+}
+
+module "arm-build-pool" {
+  source = "./azp-build-asg"
+
+  ami_prefix           = "envoy-azp-arm64"
+  aws_account_id       = "457956385456"
+  azp_pool_name        = "arm-large"
+  azp_token            = var.azp_token
+  disk_size_gb         = 1000
+  idle_instances_count = 1
+  instance_type        = "r6g.8xlarge"
+  bazel_cache_bucket   = aws_s3_bucket.build-cache.bucket
+  cache_prefix         = "public-arm64"
+
+  providers = {
+    aws = aws
+  }
+}

--- a/instances/remote-state-bucket.tf
+++ b/instances/remote-state-bucket.tf
@@ -1,0 +1,18 @@
+resource "aws_s3_bucket" "remote-state-bucket" {
+  bucket = "envoy-build-tf-remote-state-us-east-2"
+  acl    = "private"
+
+  tags = {
+    Environment = "Production"
+  }
+}
+
+terraform {
+  backend "s3" {
+    bucket = "envoy-build-tf-remote-state-us-east-2"
+    key    = "github/envoyproxy/envoy-build-tools/terraform.tfstate"
+    region = "us-east-2"
+  }
+
+  required_version = ">= 0.12"
+}

--- a/instances/s3.tf
+++ b/instances/s3.tf
@@ -1,0 +1,29 @@
+resource "aws_s3_bucket" "token" {
+  bucket = "cncf-envoy-token"
+  acl    = "private"
+  region = "us-east-1"
+
+  tags = {
+    Environment = "Production"
+  }
+  provider = aws.us-east-1
+}
+
+resource "aws_s3_bucket" "build-cache" {
+  bucket = "envoy-ci-build-cache-us-east-2"
+  acl    = "private"
+
+  tags = {
+    Environment = "Production"
+  }
+
+  lifecycle_rule {
+    id      = "all"
+    enabled = true
+    prefix  = ""
+
+    expiration {
+      days = 10
+    }
+  }
+}

--- a/instances/vpc.tf
+++ b/instances/vpc.tf
@@ -1,0 +1,12 @@
+resource "aws_default_vpc" "default" {
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = aws_default_vpc.default.id
+  service_name = "com.amazonaws.us-east-2.s3"
+}
+
+resource "aws_vpc_endpoint_route_table_association" "private_s3" {
+  vpc_endpoint_id = aws_vpc_endpoint.s3.id
+  route_table_id  = aws_default_vpc.default.default_route_table_id
+}


### PR DESCRIPTION
This PR based on https://github.com/envoyproxy/envoy-build-tools/pull/83, and moved everything to us-east-2 (except the token bucket) with some renames.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>