### PR TITLE
remove placement group from ASG

### DIFF
--- a/instances/azp-build-asg/instances.tf
+++ b/instances/azp-build-asg/instances.tf
@@ -29,9 +29,9 @@ data "template_file" "init" {
   }
 }
 
-resource "aws_placement_group" "spread" {
-  name     = "${var.ami_prefix}_${var.azp_pool_name}_placement_group"
-  strategy = "spread"
+resource "aws_placement_group" "partition" {
+  name     = "${var.ami_prefix}_${var.azp_pool_name}_partition_placement_group"
+  strategy = "partition"
 }
 
 resource "aws_launch_template" "build_pool" {
@@ -70,7 +70,7 @@ resource "aws_launch_template" "build_pool" {
 
 resource "aws_autoscaling_group" "build_pool" {
   name            = local.asg_name
-  placement_group = aws_placement_group.spread.id
+  placement_group = aws_placement_group.partition.id
 
   min_size         = var.idle_instances_count
   desired_capacity = var.idle_instances_count

--- a/instances/azp-build-asg/instances.tf
+++ b/instances/azp-build-asg/instances.tf
@@ -29,11 +29,6 @@ data "template_file" "init" {
   }
 }
 
-resource "aws_placement_group" "partition" {
-  name     = "${var.ami_prefix}_${var.azp_pool_name}_partition_placement_group"
-  strategy = "partition"
-}
-
 resource "aws_launch_template" "build_pool" {
   name_prefix   = "${var.ami_prefix}_${var.azp_pool_name}"
   image_id      = data.aws_ami.azp_ci_image.id
@@ -70,7 +65,6 @@ resource "aws_launch_template" "build_pool" {
 
 resource "aws_autoscaling_group" "build_pool" {
   name            = local.asg_name
-  placement_group = aws_placement_group.partition.id
 
   min_size         = var.idle_instances_count
   desired_capacity = var.idle_instances_count


### PR DESCRIPTION
From AWS doc, with spread placement group: 
> You can have a maximum of seven running instances per Availability Zone per group.

We sometime hit this limit while not need it to be spread.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>