### PR TITLE
Run the cleanup lambda weekly instead of daily.

### DIFF
--- a/instances/cloudwatch.tf
+++ b/instances/cloudwatch.tf
@@ -1,11 +1,11 @@
-resource "aws_cloudwatch_event_rule" "every_day" {
-  name                = "every-day"
-  description         = "Fires once every day"
-  schedule_expression = "rate(1 day)"
+resource "aws_cloudwatch_event_rule" "every_week" {
+  name                = "every-week"
+  description         = "Fires once every week"
+  schedule_expression = "rate(7 day)"
 }
 
-resource "aws_cloudwatch_event_target" "cleanup_every_day" {
-  rule      = aws_cloudwatch_event_rule.every_day.name
+resource "aws_cloudwatch_event_target" "cleanup_every_week" {
+  rule      = aws_cloudwatch_event_rule.every_week.name
   target_id = "cleanup_amis_daily"
   arn       = aws_lambda_function.cleanup_lambda.arn
 }
@@ -15,7 +15,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_cleanup" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.cleanup_lambda.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.every_day.arn
+  source_arn    = aws_cloudwatch_event_rule.every_week.arn
 }
 
 resource "aws_cloudwatch_event_rule" "ec2_terminate" {


### PR DESCRIPTION
This will give us more time to roll back to the old AMIs if need be.

Signed-off-by: Jakub Sobon <jakub.sobon@elohim.sk>