### PR TITLE
ami: Add `bazelisk` `expect` and `skopeo` into environment + allow `sudo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ The general idea is:
   - AMIs are built with all necessary tooling, for Linux this includes:
     - [`azure-pipelines-agent`](https://github.com/microsoft/azure-pipelines-agent),
       `awscli` and `jq` for agent setup.
+    - `bazelisk`
     - `docker`
+    - `skopeo`
+    - `expect` for example testing.
     - [`bazel-remote`](https://github.com/buchgr/bazel-remote) for local S3 bazel cache proxy.
 
   - AMIs are referenced by a launch template for an ASG.


### PR DESCRIPTION
this allows the self-hosted images to be used to run example verification and the docker build

currently this is not possible as the self-hosted images dont have sudo or included utils

Fix #14 