### PR TITLE
ami/os: Update to Ubuntu Jammy (22.04)

### DIFF
--- a/ami-build/agent-setup.sh
+++ b/ami-build/agent-setup.sh
@@ -28,7 +28,7 @@ echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:
 curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_22.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_stable.gpg > /dev/null
 
 sudo apt-get -qq update
-sudo apt-get -qq install -y docker-ce docker-ce-cli containerd.io git awscli jq inotify-tools expect skopeo zstd
+sudo apt-get -qq install -y docker-ce docker-ce-cli containerd.io git awscli jq inotify-tools expect skopeo zstd libicu67 libssl3 libicu70
 
 sudo mkdir -p /etc/docker
 echo '{

--- a/ami-build/agent-setup.sh
+++ b/ami-build/agent-setup.sh
@@ -28,7 +28,7 @@ echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:
 curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_22.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_stable.gpg > /dev/null
 
 sudo apt-get -qq update
-sudo apt-get -qq install -y docker-ce docker-ce-cli containerd.io git awscli jq inotify-tools expect skopeo zstd libicu67 libssl3 libicu70
+sudo apt-get -qq install -y docker-ce docker-ce-cli containerd.io git awscli jq inotify-tools expect skopeo zstd liblttng-ust1 libssl3 libicu70
 
 sudo mkdir -p /etc/docker
 echo '{

--- a/ami-build/azp-arm64.json
+++ b/ami-build/azp-arm64.json
@@ -7,7 +7,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-*",
+          "name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*",
           "root-device-type": "ebs"
         },
         "owners": [

--- a/ami-build/azp-x64.json
+++ b/ami-build/azp-x64.json
@@ -7,7 +7,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*",
+          "name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*",
           "root-device-type": "ebs"
         },
         "owners": [


### PR DESCRIPTION
This should include a kernel which supports `io_uring`

Fix #18 