### PR TITLE
Modernize the Terraform configs.

### DIFF
--- a/instances/azp-build-asg/main.tf
+++ b/instances/azp-build-asg/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/instances/main.tf
+++ b/instances/main.tf
@@ -1,10 +1,19 @@
-provider "aws" {
-  region  = "us-east-2"
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
 }
 
 provider "aws" {
-  alias   = "us-east-1"
-  region  = "us-east-1"
+  region = "us-east-2"
+}
+
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
 }
 
 module "x64-large-build-pool" {


### PR DESCRIPTION
- formatted all Terraform input files.
- migrate from [terraform-provider-template](https://github.com/hashicorp/terraform-provider-template) which has been deprecated and is [no longer supported](https://github.com/hashicorp/terraform-provider-template/issues/85) to the native [templatefile](https://developer.hashicorp.com/terraform/language/functions/templatefile) function.
- added missing provider definition for the `aws` provider to remove a warning:
```
│ Warning: Reference to undefined provider
│
│   on [main.tf](http://main.tf/) line 24, in module "x64-large-build-pool":
│   24:     aws = aws
│
│ There is no explicit declaration for local provider name "aws" in module.x64-large-build-pool, so Terraform is assuming you mean to pass a configuration for "hashicorp/aws".
│
│ If you also control the child module, add a required_providers entry named "aws" with the source address "hashicorp/aws".
│
│ (and one more similar warning elsewhere)
```

Confirmed this introduces no changes to the infrastructure by running Terraform apply:
```
$ terraform apply
...
No changes. Your infrastructure matches the configuration.
```