### PR TITLE
Remove the S3 lifecycle rule.

### DIFF
--- a/instances/s3.tf
+++ b/instances/s3.tf
@@ -15,14 +15,4 @@ resource "aws_s3_bucket" "build-cache" {
   tags = {
     Environment = "Production"
   }
-
-  lifecycle_rule {
-    id      = "all"
-    enabled = true
-    prefix  = ""
-
-    expiration {
-      days = 10
-    }
-  }
 }


### PR DESCRIPTION
This deletes objects 10 days after their creation (not the last use), so can interfere with the state of bazel-remote.