### PR TITLE
Enable versioning on the Terraform state bucket.

### DIFF
--- a/instances/remote-state-bucket.tf
+++ b/instances/remote-state-bucket.tf
@@ -7,6 +7,26 @@ resource "aws_s3_bucket" "remote-state-bucket" {
   }
 }
 
+resource "aws_s3_bucket_versioning" "remote-state-bucket-versioning" {
+  bucket = aws_s3_bucket.remote-state-bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "remote-state-bucket-lifecycle" {
+  bucket = aws_s3_bucket.remote-state-bucket.id
+
+  rule {
+    id = "keep-100-noncurrent-versions-for-a-year"
+    status = "Enabled"
+    noncurrent_version_expiration {
+      newer_noncurrent_versions = 100
+      noncurrent_days = 365
+    }
+  }
+}
+
 terraform {
   backend "s3" {
     bucket = "envoy-build-tf-remote-state-us-east-2"


### PR DESCRIPTION
Will ease recovery of any state corruption.

The state only changes when we run `terraform apply`. A single state instance takes ~120kB, so in an extreme case of 1 change per day, this will use <50MB in total.

The lifecycle policy is configured to keep versions for a year and keep a minimum of the last 100 versions.
