### PR TITLE
Initial infrastructure for Salvo.

### DIFF
--- a/salvo-infra/README.md
+++ b/salvo-infra/README.md
@@ -1,0 +1,11 @@
+# Salvo Infrastructure
+
+This defines the infrastructure that needs to be always-on and NOT the
+individual sandboxes used to execute tests. The sandboxes are created at
+runtime  by Salvo.
+
+See also:
+
+- Salvo docs: https://github.com/envoyproxy/envoy-perf/tree/main/salvo-remote
+- Terraform docs: https://developer.hashicorp.com/terraform/language
+- AWS provider docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs

--- a/salvo-infra/main.tf
+++ b/salvo-infra/main.tf
@@ -1,0 +1,14 @@
+# Infrastructure for Salvo.
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.61"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-2"
+}

--- a/salvo-infra/salvo-infra-remote-state-bucket.tf
+++ b/salvo-infra/salvo-infra-remote-state-bucket.tf
@@ -1,0 +1,39 @@
+# The S3 bucket where Terraform for the salvo infra stores its state.
+
+resource "aws_s3_bucket" "salvo-infra-remote-state-bucket" {
+  bucket = "salvo-infra-tf-remote-state-us-east-2"
+
+  tags = {
+    Environment = "Production"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "salvo-infra-remote-state-bucket-versioning" {
+  bucket = aws_s3_bucket.salvo-infra-remote-state-bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "salvo-infra-remote-state-bucket-lifecycle" {
+  bucket = aws_s3_bucket.salvo-infra-remote-state-bucket.id
+
+  rule {
+    id     = "keep-100-noncurrent-versions-for-a-year"
+    status = "Enabled"
+    noncurrent_version_expiration {
+      newer_noncurrent_versions = 100
+      noncurrent_days           = 365
+    }
+  }
+}
+
+terraform {
+  backend "s3" {
+    bucket = "salvo-infra-tf-remote-state-us-east-2"
+    key    = "salvo/infra/terraform.tfstate"
+    region = "us-east-2"
+  }
+
+  required_version = ">= 1.4"
+}

--- a/salvo-infra/vpc.tf
+++ b/salvo-infra/vpc.tf
@@ -1,0 +1,113 @@
+# The VPN and subnets where Salvo runs its infrastructure and Sandboxes.
+
+resource "aws_vpc" "salvo-vpc" {
+  cidr_block = "192.168.0.0/16"
+
+  tags = {
+    Name = "salvo-vpc"
+  }
+}
+
+resource "aws_vpc_dhcp_options" "default-dhcp-options" {
+  domain_name         = "us-east-2.compute.internal"
+  domain_name_servers = ["AmazonProvidedDNS"]
+}
+
+resource "aws_vpc_dhcp_options_association" "salvo-vpc-default-dhcp-options" {
+  vpc_id          = aws_vpc.salvo-vpc.id
+  dhcp_options_id = aws_vpc_dhcp_options.default-dhcp-options.id
+}
+
+resource "aws_internet_gateway" "salvo-internet-gateway" {
+  vpc_id = aws_vpc.salvo-vpc.id
+
+  tags = {
+    Name = "salvo-internet-gateway"
+  }
+}
+
+resource "aws_route_table" "salvo-infra-route-table" {
+  vpc_id = aws_vpc.salvo-vpc.id
+}
+
+resource "aws_route_table_association" "salvo-packer-subnet-salvo-infra-route-table" {
+  subnet_id      = aws_subnet.salvo-packer-subnet.id
+  route_table_id = aws_route_table.salvo-infra-route-table.id
+}
+
+resource "aws_subnet" "salvo-packer-subnet" {
+  vpc_id     = aws_vpc.salvo-vpc.id
+  cidr_block = "192.168.0.0/24"
+
+  tags = {
+    Name    = "salvo-packer-subnet"
+    Project = "Packer"
+  }
+}
+
+resource "aws_route_table_association" "salvo-internet-gateway-salvo-infra-route-table" {
+  gateway_id     = aws_internet_gateway.salvo-internet-gateway.id
+  route_table_id = aws_route_table.salvo-infra-route-table.id
+}
+
+resource "aws_default_network_acl" "salvo-vpc-default-acl" {
+  default_network_acl_id = aws_vpc.salvo-vpc.default_network_acl_id
+  subnet_ids             = [aws_subnet.salvo-packer-subnet.id]
+
+  egress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  ingress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+}
+
+resource "aws_default_security_group" "salvo-vpc-default-security-group" {
+  vpc_id = aws_vpc.salvo-vpc.id
+
+  ingress {
+    protocol  = -1
+    self      = true
+    from_port = 0
+    to_port   = 0
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "salvo-allow-ssh-from-world-security-group" {
+  name        = "salvo-allow-ssh-from-world"
+  description = "Allow SSH access form the World."
+  vpc_id      = aws_vpc.salvo-vpc.id
+
+  ingress {
+    description = "Allow SSH from the World."
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}


### PR DESCRIPTION
Defining initial objects for Salvo, includes:

- S3 bucket for Terraform state.
- the VPC, subnets and the Internet gateway.
- the default network ACL.
- security groups.

Only defining the subnet and security groups needed for Packer when creating VM images. More to be added later.