### PR TITLE
Move Salvo infrastructure to the us-west-1 region.

### DIFF
--- a/salvo-infra/main.tf
+++ b/salvo-infra/main.tf
@@ -10,5 +10,5 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-east-2"
+  region = "us-west-1"
 }

--- a/salvo-infra/salvo-infra-remote-state-bucket.tf
+++ b/salvo-infra/salvo-infra-remote-state-bucket.tf
@@ -1,7 +1,7 @@
 # The S3 bucket where Terraform for the salvo infra stores its state.
 
 resource "aws_s3_bucket" "salvo-infra-remote-state-bucket" {
-  bucket = "salvo-infra-tf-remote-state-us-east-2"
+  bucket = "salvo-infra-tf-remote-state-us-west-1"
 
   tags = {
     Environment = "Production"
@@ -30,9 +30,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "salvo-infra-remote-state-bucke
 
 terraform {
   backend "s3" {
-    bucket = "salvo-infra-tf-remote-state-us-east-2"
+    bucket = "salvo-infra-tf-remote-state-us-west-1"
     key    = "salvo/infra/terraform.tfstate"
-    region = "us-east-2"
+    region = "us-west-1"
   }
 
   required_version = ">= 1.4"

--- a/salvo-infra/vpc.tf
+++ b/salvo-infra/vpc.tf
@@ -1,58 +1,58 @@
 # The VPN and subnets where Salvo runs its infrastructure and Sandboxes.
 
-resource "aws_vpc" "salvo-vpc" {
+resource "aws_vpc" "salvo-infra-vpc" {
   cidr_block = "192.168.0.0/16"
 
   tags = {
-    Name = "salvo-vpc"
+    Name = "salvo-infra-vpc"
   }
 }
 
 resource "aws_vpc_dhcp_options" "default-dhcp-options" {
-  domain_name         = "us-east-2.compute.internal"
+  domain_name         = "us-west-1.compute.internal"
   domain_name_servers = ["AmazonProvidedDNS"]
 }
 
-resource "aws_vpc_dhcp_options_association" "salvo-vpc-default-dhcp-options" {
-  vpc_id          = aws_vpc.salvo-vpc.id
+resource "aws_vpc_dhcp_options_association" "salvo-infra-vpc-default-dhcp-options" {
+  vpc_id          = aws_vpc.salvo-infra-vpc.id
   dhcp_options_id = aws_vpc_dhcp_options.default-dhcp-options.id
 }
 
-resource "aws_internet_gateway" "salvo-internet-gateway" {
-  vpc_id = aws_vpc.salvo-vpc.id
+resource "aws_internet_gateway" "salvo-infra-internet-gateway" {
+  vpc_id = aws_vpc.salvo-infra-vpc.id
 
   tags = {
-    Name = "salvo-internet-gateway"
+    Name = "salvo-infra-internet-gateway"
   }
 }
 
 resource "aws_route_table" "salvo-infra-route-table" {
-  vpc_id = aws_vpc.salvo-vpc.id
+  vpc_id = aws_vpc.salvo-infra-vpc.id
 }
 
-resource "aws_route_table_association" "salvo-packer-subnet-salvo-infra-route-table" {
-  subnet_id      = aws_subnet.salvo-packer-subnet.id
+resource "aws_route_table_association" "salvo-infra-packer-subnet-salvo-infra-route-table" {
+  subnet_id      = aws_subnet.salvo-infra-packer-subnet.id
   route_table_id = aws_route_table.salvo-infra-route-table.id
 }
 
-resource "aws_subnet" "salvo-packer-subnet" {
-  vpc_id     = aws_vpc.salvo-vpc.id
+resource "aws_subnet" "salvo-infra-packer-subnet" {
+  vpc_id     = aws_vpc.salvo-infra-vpc.id
   cidr_block = "192.168.0.0/24"
 
   tags = {
-    Name    = "salvo-packer-subnet"
+    Name    = "salvo-infra-packer-subnet"
     Project = "Packer"
   }
 }
 
-resource "aws_route_table_association" "salvo-internet-gateway-salvo-infra-route-table" {
-  gateway_id     = aws_internet_gateway.salvo-internet-gateway.id
+resource "aws_route_table_association" "salvo-infra-internet-gateway-salvo-infra-route-table" {
+  gateway_id     = aws_internet_gateway.salvo-infra-internet-gateway.id
   route_table_id = aws_route_table.salvo-infra-route-table.id
 }
 
-resource "aws_default_network_acl" "salvo-vpc-default-acl" {
-  default_network_acl_id = aws_vpc.salvo-vpc.default_network_acl_id
-  subnet_ids             = [aws_subnet.salvo-packer-subnet.id]
+resource "aws_default_network_acl" "salvo-infra-vpc-default-acl" {
+  default_network_acl_id = aws_vpc.salvo-infra-vpc.default_network_acl_id
+  subnet_ids             = [aws_subnet.salvo-infra-packer-subnet.id]
 
   egress {
     protocol   = -1
@@ -73,8 +73,8 @@ resource "aws_default_network_acl" "salvo-vpc-default-acl" {
   }
 }
 
-resource "aws_default_security_group" "salvo-vpc-default-security-group" {
-  vpc_id = aws_vpc.salvo-vpc.id
+resource "aws_default_security_group" "salvo-infra-vpc-default-security-group" {
+  vpc_id = aws_vpc.salvo-infra-vpc.id
 
   ingress {
     protocol  = -1
@@ -91,10 +91,10 @@ resource "aws_default_security_group" "salvo-vpc-default-security-group" {
   }
 }
 
-resource "aws_security_group" "salvo-allow-ssh-from-world-security-group" {
-  name        = "salvo-allow-ssh-from-world"
+resource "aws_security_group" "salvo-infra-allow-ssh-from-world-security-group" {
+  name        = "salvo-infra-allow-ssh-from-world"
   description = "Allow SSH access form the World."
-  vpc_id      = aws_vpc.salvo-vpc.id
+  vpc_id      = aws_vpc.salvo-infra-vpc.id
 
   ingress {
     description = "Allow SSH from the World."


### PR DESCRIPTION
This will simplify cost accounting as it physically segregates Salvo from Envoy's CI.

Also taking the opportunity to rename a few objects for consistency, since we are creating them anew. Ensuring that all objects have the prefix `salvo-infra` which will enable us to find good names for the VPC and objects related to Salvo sandboxes once we add them in the future.