### PR TITLE
Packer definition for a Salvo AZP Agent VM AMI.

### DIFF
--- a/salvo-infra/azp-agent-vm-ami/README.md
+++ b/salvo-infra/azp-agent-vm-ami/README.md
@@ -1,0 +1,5 @@
+# Salvo AZP Agent VM AMI Build
+
+This is a series of [Packer](https://www.packer.io/) scripts to build the AMI
+for a VM that runs the Azure Pipelines (AZP) agent. This VM is part of an auto
+scaling group and picks up Salvo job from the CI pipeline.

--- a/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm-x64.pkr.hcl
+++ b/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm-x64.pkr.hcl
@@ -1,0 +1,59 @@
+# Defines a Packer template that builds an AMI image of a Salvo VM that runs
+# the AZP Agent.
+
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 1.2.1"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+# See https://developer.hashicorp.com/packer/plugins/builders/amazon/ebs.
+source "amazon-ebs" "salvo-azp-agent-vm-x64" {
+  ami_name                    = "salvo-azp-agent-vm-x64-{{timestamp}}"
+  instance_type               = "m6i.large"
+  region                      = "us-west-1"
+  vpc_id                      = "vpc-0b1493d6a970c32bd" # salvo-infra-vpc
+  associate_public_ip_address = true
+  subnet_id                   = "subnet-0d07ecf83aad87c08" # salvo-infra-packer-subnet
+
+  source_ami_filter {
+    filters = {
+      # Found with:
+      # aws ec2 describe-images --owners 'aws-marketplace' --output json --region us-east-2 --filters "Name=product-code,Values=4s6b2r2vfe46kyul508kf459f"
+      name                = "ubuntu-minimal/images/hvm-ssd/ubuntu-jammy-22.04-amd64-minimal-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["679593333241"]
+  }
+  encrypt_boot = true
+  ssh_username = "ubuntu"
+
+  run_tags = {
+    "Project" : "Packer"
+  }
+  run_volume_tags = {
+    "Project" : "Packer"
+  }
+  tags = {
+    "Project" : "Salvo",
+    "AmiType" : "salvo-azp-agent-vm-x64"
+  }
+}
+
+build {
+  name = "salvo-azp-agent-vm-x64"
+  sources = [
+    "source.amazon-ebs.salvo-azp-agent-vm-x64"
+  ]
+
+  # See https://developer.hashicorp.com/packer/docs/provisioners/shell.
+  provisioner "shell" {
+    script          = "salvo-azp-agent-vm.sh"
+    execute_command = "{{.Vars}} sudo -S -E sh -eux '{{.Path}}'"
+  }
+}

--- a/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm.sh
+++ b/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+
+# The version of the AZP agent to use.
+# See https://github.com/microsoft/azure-pipelines-agent/releases.
+AGENT_VERSION=2.218.1
+
+# Determine the architecture and package versions.
+ARCH=$(dpkg --print-architecture)
+if [ "${ARCH}" = "amd64" ]; then
+  ARCH="x64"
+  AWS_ARCH="x86_64"
+else
+  AWS_ARCH="aarch64"
+fi
+AGENT_FILE=vsts-agent-linux-${ARCH}-${AGENT_VERSION}
+
+# Upgrade installed packages.
+apt-get -qq update
+apt-get -qq upgrade -y
+
+# Insgtall required packages.
+apt-get -qq install -y \
+  unzip `# Needed to install AWS CLI.` \
+  wget  `# Used in this script.`
+
+# Workaround for AWSCLI that requires an older version of libssl.
+# Forcing libssl.so.1.1.
+# See https://github.com/microsoft/azure-pipelines-agent/issues/3834#issuecomment-1231742801.
+LIBSSL1_DIR="/tmp/libssl1"
+wget -q -r -l1 -np \
+  -P "${LIBSSL1_DIR}" \
+  -A 'libssl1.1_1.1.1*ubuntu*amd64.deb' \
+  "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/"
+LIBSSL1_PACKAGE=`find "${LIBSSL1_DIR}" -type f -name \*.deb | sort | head -n 1`
+dpkg -i "${LIBSSL1_PACKAGE}"
+sed -i 's/openssl_conf = openssl_init/#openssl_conf = openssl_init/g' /etc/ssl/openssl.cnf
+
+# Setup a local user to run the AZP agent.
+groupadd azure-pipelines
+useradd -ms /bin/bash -g azure-pipelines azure-pipelines
+sudo mkdir -p /srv/azure-pipelines
+sudo chown -R azure-pipelines:azure-pipelines /srv/azure-pipelines/
+
+# Install the AZP agent.
+sudo -u azure-pipelines /bin/bash -c "wget -q -O - https://vstsagentpackage.azureedge.net/agent/${AGENT_VERSION}/${AGENT_FILE}.tar.gz | tar zx -C /srv/azure-pipelines"
+# The following script tries to install both liblttng-ust0 and liblttng-ust1,
+# only one is expected to exist, so ignoring errors here.
+set +e
+sudo /srv/azure-pipelines/bin/installdependencies.sh
+set -e
+
+sudo -u azure-pipelines /bin/bash -c 'mkdir -p /home/azure-pipelines/.ssh && touch /home/azure-pipelines/.ssh/known_hosts'
+sudo -u azure-pipelines /bin/bash -c 'ssh-keyscan github.com | tee /home/azure-pipelines/.ssh/known_hosts'
+
+# Allow password-less sudo for the AZP agent.
+echo 'azure-pipelines ALL=(ALL) NOPASSWD:ALL' | sudo tee -a /etc/sudoers
+
+# Install AWS CLI.
+# https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+wget -q -O awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}.zip"
+unzip awscliv2.zip
+./aws/install

--- a/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm.sh
+++ b/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm.sh
@@ -5,7 +5,7 @@ set -e
 # The version of the AZP agent to use.
 # See https://github.com/microsoft/azure-pipelines-agent/releases.
 AGENT_VERSION=2.218.1
-
+export DEBIAN_FRONTEND=noninteractive
 # Determine the architecture and package versions.
 ARCH=$(dpkg --print-architecture)
 if [ "${ARCH}" = "amd64" ]; then

--- a/salvo-infra/vpc.tf
+++ b/salvo-infra/vpc.tf
@@ -28,6 +28,11 @@ resource "aws_internet_gateway" "salvo-infra-internet-gateway" {
 
 resource "aws_route_table" "salvo-infra-route-table" {
   vpc_id = aws_vpc.salvo-infra-vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.salvo-infra-internet-gateway.id
+  }
 }
 
 resource "aws_route_table_association" "salvo-infra-packer-subnet-salvo-infra-route-table" {
@@ -43,11 +48,6 @@ resource "aws_subnet" "salvo-infra-packer-subnet" {
     Name    = "salvo-infra-packer-subnet"
     Project = "Packer"
   }
-}
-
-resource "aws_route_table_association" "salvo-infra-internet-gateway-salvo-infra-route-table" {
-  gateway_id     = aws_internet_gateway.salvo-infra-internet-gateway.id
-  route_table_id = aws_route_table.salvo-infra-route-table.id
 }
 
 resource "aws_default_network_acl" "salvo-infra-vpc-default-acl" {


### PR DESCRIPTION
Uses `ubuntu-jammy-22.04-amd64-minimal` image and includes workarounds to make the AZP agent work with that image. We can afford to test these workarounds here, since this is non-production at this points.

Also removing an AWS edge association to internet gateway and adding a default route instead, since routing to the internet doesn't work with the association.