### PR TITLE
Migrating to the new pool names.

### DIFF
--- a/instances/main.tf
+++ b/instances/main.tf
@@ -21,7 +21,7 @@ module "x64-large-build-pool" {
 
   ami_prefix           = "envoy-azp-x64"
   aws_account_id       = "457956385456"
-  azp_pool_name        = "x64-large"
+  azp_pool_name        = "envoy-x64-large"
   azp_token            = var.azp_token
   disk_size_gb         = 2000
   idle_instances_count = 1
@@ -39,7 +39,7 @@ module "arm-build-pool" {
 
   ami_prefix           = "envoy-azp-arm64"
   aws_account_id       = "457956385456"
-  azp_pool_name        = "arm-large"
+  azp_pool_name        = "envoy-arm-large"
   azp_token            = var.azp_token
   disk_size_gb         = 1000
   idle_instances_count = 1


### PR DESCRIPTION
These pools are set in a way that we have the ability to manage them. We don't have those permissions on the old ones.