### PR TITLE
Infrastructure for the new `salvo-control` AZP pool.

### DIFF
--- a/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm-x64.pkr.hcl
+++ b/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm-x64.pkr.hcl
@@ -51,6 +51,11 @@ build {
     "source.amazon-ebs.salvo-azp-agent-vm-x64"
   ]
 
+  provisioner "file" {
+    source = "../../ami-build/scripts/"
+    destination = "/home/ubuntu/scripts"
+  }
+
   # See https://developer.hashicorp.com/packer/docs/provisioners/shell.
   provisioner "shell" {
     script          = "salvo-azp-agent-vm.sh"

--- a/salvo-infra/azp-salvo-asg/iam.tf
+++ b/salvo-infra/azp-salvo-asg/iam.tf
@@ -1,4 +1,5 @@
-# Creates an IAM Role where instances themselves can then detach themselves from ASG.
+# Creates an IAM Role where instances can then detach themselves from the Auto
+# Scaling Group.
 data "aws_iam_policy_document" "asg_detach_salvo_instances" {
   statement {
     actions = [

--- a/salvo-infra/azp-salvo-asg/iam.tf
+++ b/salvo-infra/azp-salvo-asg/iam.tf
@@ -1,0 +1,104 @@
+# Creates an IAM Role where instances themselves can then detach themselves from ASG.
+data "aws_iam_policy_document" "asg_detach_salvo_instances" {
+  statement {
+    actions = [
+      "autoscaling:DetachInstances"
+    ]
+
+    resources = [
+      "arn:aws:autoscaling:*:${var.aws_account_id}:autoScalingGroup:*:autoScalingGroupName/${local.asg_name}",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "salvo_instance_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "asg_salvo_iam_role" {
+  name               = "${var.ami_prefix}_${var.azp_pool_name}_IAMRole"
+  assume_role_policy = data.aws_iam_policy_document.salvo_instance_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy" "asg_salvo_iam_role_policy" {
+  name   = "${var.ami_prefix}_${var.azp_pool_name}_IAMRolePolicy"
+  role   = aws_iam_role.asg_salvo_iam_role.id
+  policy = data.aws_iam_policy_document.asg_detach_salvo_instances.json
+}
+
+resource "aws_iam_instance_profile" "asg_salvo_iam_instance_profile" {
+  name = "${var.ami_prefix}_${var.azp_pool_name}_IProfile"
+  role = aws_iam_role.asg_salvo_iam_role.name
+}
+
+# Creates an IAM Role where instances can get token and associate with running IAM profile.
+data "aws_iam_policy_document" "init_salvo_permissions" {
+  statement {
+    actions = [
+      "s3:GetObject"
+    ]
+
+    resources = [
+      "arn:aws:s3:::cncf-envoy-token/azp_token",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ec2:ReplaceIamInstanceProfileAssociation"
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ARN"
+      values   = ["$${ec2:SourceInstanceARN}"]
+    }
+  }
+
+  statement {
+    actions = [
+      "iam:PassRole"
+    ]
+
+    resources = [
+      aws_iam_role.asg_salvo_iam_role.arn
+    ]
+  }
+
+  statement {
+    actions = [
+      "ec2:DescribeIamInstanceProfileAssociations"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "asg_salvo_init_iam_role" {
+  name               = "${var.ami_prefix}_${var.azp_pool_name}_init_IAMRole"
+  assume_role_policy = data.aws_iam_policy_document.salvo_instance_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy" "asg_salvo_init_iam_role_policy" {
+  name   = "${var.ami_prefix}_${var.azp_pool_name}_init_IAMRolePolicy"
+  role   = aws_iam_role.asg_salvo_init_iam_role.id
+  policy = data.aws_iam_policy_document.init_salvo_permissions.json
+}
+
+resource "aws_iam_instance_profile" "asg_salvo_init_iam_instance_profile" {
+  name = "${var.ami_prefix}_${var.azp_pool_name}_init_IProfile"
+  role = aws_iam_role.asg_salvo_init_iam_role.name
+}

--- a/salvo-infra/azp-salvo-asg/init.sh.tpl
+++ b/salvo-infra/azp-salvo-asg/init.sh.tpl
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# This is a template of an initialization script used by the Salvo Control VMs.
+
 set -e
 
 function terminate {

--- a/salvo-infra/azp-salvo-asg/init.sh.tpl
+++ b/salvo-infra/azp-salvo-asg/init.sh.tpl
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+function terminate {
+    # Terminate instances in 1 min
+    shutdown -h +1
+}
+trap terminate EXIT
+
+
+# shellcheck source=ami-build/scripts/run-fun.sh
+. /usr/local/share/run-fun.sh
+
+AWS_DEFAULT_REGION="$(aws_get_region)"
+export AWS_DEFAULT_REGION
+
+
+# shellcheck disable=SC2154
+agent_start_minimal \
+    "${azp_pool_name}" \
+    "${asg_name}" \
+    "${instance_profile_arn}" \
+    "${role_name}"

--- a/salvo-infra/azp-salvo-asg/inputs.tf
+++ b/salvo-infra/azp-salvo-asg/inputs.tf
@@ -1,0 +1,46 @@
+# The VPC used by Salvo.
+variable "salvo_vpc" {
+  type = object({ id = string })
+}
+
+# The subnet in which all Salvo Control VMs should be started.
+# Control VMs are VMs that run the AZP agent and the Salvo controller and
+# instrument execution of the Salvo pipeline.
+variable "salvo_control_vm_subnet" {
+  type = object({ id = string })
+}
+
+# The security group to apply to all the Salvo Control VM instances.
+variable "salvo_control_vm_security_group" {
+  type = object({ id = string })
+}
+
+# Prefix match on the AMIs that should be used for the control VMs.
+variable "ami_prefix" { type = string }
+
+# The account ID under which the resources are deployed.
+variable "aws_account_id" { type = string }
+
+# The name of the AZP pool that receives jobs fro the Salvo control VMs.
+variable "azp_pool_name" { type = string }
+
+# Token used when the AZP agent on the control VM registers with the AZP pool.
+variable "azp_token" { type = string }
+
+# The disk size of the Salvo control VMs in GB.
+variable "disk_size_gb" { type = number }
+
+# The number of on-demand instances to keep in the pool.
+# These are more available, but also more expensive when compared to the spot
+# instances.
+variable "on_demand_instances_count" {
+  type    = number
+  default = 0
+}
+
+# The number of Salvo control VM instances to keep active in the auto scaling
+# group.
+variable "idle_instances_count" { type = number }
+
+# The instance types to use in the pool.
+variable "instance_types" { type = list(string) }

--- a/salvo-infra/azp-salvo-asg/inputs.tf
+++ b/salvo-infra/azp-salvo-asg/inputs.tf
@@ -1,3 +1,5 @@
+# This file contains the input variables for this Terraform module.
+
 # The VPC used by Salvo.
 variable "salvo_vpc" {
   type = object({ id = string })

--- a/salvo-infra/azp-salvo-asg/instances.tf
+++ b/salvo-infra/azp-salvo-asg/instances.tf
@@ -1,3 +1,6 @@
+# This file defines resources needed to deploy an Auto Scaling Group of Salvo
+# Control VMs.
+
 locals {
   asg_name = "${var.ami_prefix}_${var.azp_pool_name}_pool"
 }

--- a/salvo-infra/azp-salvo-asg/instances.tf
+++ b/salvo-infra/azp-salvo-asg/instances.tf
@@ -1,0 +1,98 @@
+locals {
+  asg_name = "${var.ami_prefix}_${var.azp_pool_name}_pool"
+}
+
+data "aws_ami" "azp_ci_image" {
+  most_recent = true
+  owners      = [var.aws_account_id]
+
+  filter {
+    name   = "name"
+    values = ["${var.ami_prefix}-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_launch_template" "salvo_pool" {
+  name_prefix   = "${var.ami_prefix}_${var.azp_pool_name}"
+  image_id      = data.aws_ami.azp_ci_image.id
+  instance_type = var.instance_types[0]
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+
+    ebs {
+      volume_size           = var.disk_size_gb
+      volume_type           = "gp2"
+      delete_on_termination = true
+      encrypted             = true
+    }
+  }
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.asg_salvo_init_iam_instance_profile.arn
+  }
+
+  monitoring {
+    enabled = true
+  }
+
+  instance_initiated_shutdown_behavior = "terminate"
+  key_name                             = "envoy-shared2"
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "optional"
+  }
+  user_data = base64encode(templatefile("${path.module}/init.sh.tpl", {
+    asg_name             = local.asg_name
+    azp_pool_name        = var.azp_pool_name
+    instance_profile_arn = aws_iam_instance_profile.asg_salvo_iam_instance_profile.arn
+    role_name            = aws_iam_role.asg_salvo_iam_role.name
+  }))
+  vpc_security_group_ids = ["$var.salvo_control_vm_security_group.id"]
+}
+
+resource "aws_autoscaling_group" "salvo_pool" {
+  name = local.asg_name
+
+  min_size         = var.idle_instances_count
+  desired_capacity = var.idle_instances_count
+  max_size         = 2
+
+  health_check_grace_period = 300
+  health_check_type         = "EC2"
+
+  mixed_instances_policy {
+    launch_template {
+      launch_template_specification {
+        launch_template_id = aws_launch_template.salvo_pool.id
+        version            = "$Latest"
+      }
+
+      dynamic "override" {
+        for_each = toset(var.instance_types)
+        content {
+          instance_type = override.key
+        }
+      }
+    }
+
+    instances_distribution {
+      on_demand_base_capacity                  = var.on_demand_instances_count
+      on_demand_percentage_above_base_capacity = 0
+      spot_allocation_strategy                 = "capacity-optimized"
+    }
+  }
+
+  tag {
+      key                 = "PoolName"
+      value               = var.azp_pool_name
+      propagate_at_launch = true
+  }
+
+  vpc_zone_identifier = ["${var.salvo_control_vm_subnet.id}"]
+}

--- a/salvo-infra/azp-salvo-asg/main.tf
+++ b/salvo-infra/azp-salvo-asg/main.tf
@@ -1,0 +1,10 @@
+# Module that defines an AWS auto scaling group of VMs that listen to requests for jobs from Azure Pipelines (AZP).
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.61"
+    }
+  }
+}

--- a/salvo-infra/azp-salvo-asg/main.tf
+++ b/salvo-infra/azp-salvo-asg/main.tf
@@ -1,4 +1,5 @@
-# Module that defines an AWS auto scaling group of VMs that listen to requests for jobs from Azure Pipelines (AZP).
+# Module that defines an AWS auto scaling group of Salvo Control VMs that
+# listen to requests for jobs from Azure Pipelines (AZP).
 
 terraform {
   required_providers {

--- a/salvo-infra/inputs.tf
+++ b/salvo-infra/inputs.tf
@@ -1,0 +1,1 @@
+variable "azp_token" { type = string }

--- a/salvo-infra/main.tf
+++ b/salvo-infra/main.tf
@@ -12,3 +12,23 @@ terraform {
 provider "aws" {
   region = "us-west-1"
 }
+
+# Pool of Salvo Control VMs.
+module "salvo-azp-agent-vm-x64-pool" {
+  source = "./azp-salvo-asg"
+
+  salvo_vpc                       = aws_vpc.salvo-infra-vpc
+  salvo_control_vm_subnet         = aws_subnet.salvo-infra-control-vm-subnet
+  salvo_control_vm_security_group = aws_security_group.salvo-infra-allow-ssh-from-world-security-group
+  ami_prefix                      = "salvo-azp-agent-vm-x64"
+  aws_account_id                  = "457956385456"
+  azp_pool_name                   = "salvo-control"
+  azp_token                       = var.azp_token
+  disk_size_gb                    = 10
+  idle_instances_count            = 0
+  instance_types                  = ["t3.nano"]
+
+  providers = {
+    aws = aws
+  }
+}

--- a/salvo-infra/vpc.tf
+++ b/salvo-infra/vpc.tf
@@ -50,6 +50,21 @@ resource "aws_subnet" "salvo-infra-packer-subnet" {
   }
 }
 
+resource "aws_route_table_association" "salvo-infra-control-vm-subnet-salvo-infra-route-table" {
+  subnet_id      = aws_subnet.salvo-infra-control-vm-subnet.id
+  route_table_id = aws_route_table.salvo-infra-route-table.id
+}
+
+resource "aws_subnet" "salvo-infra-control-vm-subnet" {
+  vpc_id     = aws_vpc.salvo-infra-vpc.id
+  cidr_block = "192.168.1.0/24"
+
+  tags = {
+    Name    = "salvo-infra-control-vm-subnet"
+    Project = "Salvo"
+  }
+}
+
 resource "aws_default_network_acl" "salvo-infra-vpc-default-acl" {
   default_network_acl_id = aws_vpc.salvo-infra-vpc.default_network_acl_id
   subnet_ids             = [aws_subnet.salvo-infra-packer-subnet.id]


### PR DESCRIPTION
This is a pool that will run Salvo control VMs, i.e. VMs that instrument the execution of the load tests. Each control VM will run an instance of the Salvo controller (which does not exist yet). The Salvo controller talks to the test driver, initiates test runs and collects results.

See the diagram in [this document](https://docs.google.com/document/d/1auXzV-AEXgMzbtdG06XlZ2d9X5l_XadMheA9h51E7yc/edit).

Notes:
- this reuses the run functions created in https://github.com/envoyproxy/ci-infra/pull/33.
- My plan is to also reuse the install functions, this will be done in a later CL.
- There isn't a complete overlap, Salvo doesn't run `bazel-remote` among other changes, since it doesn't build binaries in this VM.
- This has been tested with `terraform plan`, but not yet deployed.
- Since Salvo is in a separate VPC, the VPC ID, Subnet and security group are passed in as arguments to this module.
- Salvo has a separate Terraform state bucket and operates in a separate Region, changes here will not affect Envoy CI.