### PR TITLE
Changes necessary to allow the agent to register.

### DIFF
--- a/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm-x64.pkr.hcl
+++ b/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm-x64.pkr.hcl
@@ -56,7 +56,7 @@ build {
   }
 
   provisioner "file" {
-    source = "../../ami-build/scripts/"
+    source      = "../../ami-build/scripts/"
     destination = "/home/ubuntu/scripts/"
   }
 

--- a/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm-x64.pkr.hcl
+++ b/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm-x64.pkr.hcl
@@ -51,14 +51,18 @@ build {
     "source.amazon-ebs.salvo-azp-agent-vm-x64"
   ]
 
+  provisioner "shell" {
+    inline = ["mkdir /home/ubuntu/scripts/"]
+  }
+
   provisioner "file" {
     source = "../../ami-build/scripts/"
-    destination = "/home/ubuntu/scripts"
+    destination = "/home/ubuntu/scripts/"
   }
 
   # See https://developer.hashicorp.com/packer/docs/provisioners/shell.
   provisioner "shell" {
     script          = "salvo-azp-agent-vm.sh"
-    execute_command = "{{.Vars}} sudo -S -E sh -eux '{{.Path}}'"
+    execute_command = "{{.Vars}} sudo -S -E bash -eu '{{.Path}}'"
   }
 }

--- a/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm.sh
+++ b/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm.sh
@@ -22,6 +22,8 @@ apt-get -qq upgrade -y
 
 # Insgtall required packages.
 apt-get -qq install -y \
+  git `# Needed by the AZP agent` \
+  inotify-tools `# Needed by the AZP agent` \
   jq `# Needed in the run script.` \
   unzip `# Needed to install AWS CLI.` \
   wget  `# Used in this script.`

--- a/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm.sh
+++ b/salvo-infra/azp-agent-vm-ami/salvo-azp-agent-vm.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/bash -eu
 
-set -e
+set -o pipefail
 
 # The version of the AZP agent to use.
 # See https://github.com/microsoft/azure-pipelines-agent/releases.
@@ -22,6 +22,7 @@ apt-get -qq upgrade -y
 
 # Insgtall required packages.
 apt-get -qq install -y \
+  jq `# Needed in the run script.` \
   unzip `# Needed to install AWS CLI.` \
   wget  `# Used in this script.`
 

--- a/salvo-infra/azp-salvo-asg/init.sh.tpl
+++ b/salvo-infra/azp-salvo-asg/init.sh.tpl
@@ -11,10 +11,10 @@ function terminate {
 trap terminate EXIT
 
 
-# shellcheck source=ami-build/scripts/run-fun.sh
-. /usr/local/share/run-fun.sh
+# shellcheck source=../ami-build/scripts/run-fun.sh
+. /home/ubuntu/scripts/run-fun.sh
 
-AWS_DEFAULT_REGION="$(aws_get_region)"
+AWS_DEFAULT_REGION="us-west-1"
 export AWS_DEFAULT_REGION
 
 

--- a/salvo-infra/azp-salvo-asg/instances.tf
+++ b/salvo-infra/azp-salvo-asg/instances.tf
@@ -21,9 +21,9 @@ data "aws_ami" "azp_ci_image" {
 }
 
 resource "aws_launch_template" "salvo_pool" {
-  name_prefix   = "${var.ami_prefix}_${var.azp_pool_name}"
-  image_id      = data.aws_ami.azp_ci_image.id
-  instance_type = var.instance_types[0]
+  name_prefix            = "${var.ami_prefix}_${var.azp_pool_name}"
+  image_id               = data.aws_ami.azp_ci_image.id
+  instance_type          = var.instance_types[0]
   update_default_version = true
 
   block_device_mappings {
@@ -93,9 +93,9 @@ resource "aws_autoscaling_group" "salvo_pool" {
   }
 
   tag {
-      key                 = "PoolName"
-      value               = var.azp_pool_name
-      propagate_at_launch = true
+    key                 = "PoolName"
+    value               = var.azp_pool_name
+    propagate_at_launch = true
   }
 
   vpc_zone_identifier = ["${var.salvo_control_vm_subnet.id}"]

--- a/salvo-infra/azp-salvo-asg/instances.tf
+++ b/salvo-infra/azp-salvo-asg/instances.tf
@@ -24,6 +24,7 @@ resource "aws_launch_template" "salvo_pool" {
   name_prefix   = "${var.ami_prefix}_${var.azp_pool_name}"
   image_id      = data.aws_ami.azp_ci_image.id
   instance_type = var.instance_types[0]
+  update_default_version = true
 
   block_device_mappings {
     device_name = "/dev/sda1"

--- a/salvo-infra/vpc.tf
+++ b/salvo-infra/vpc.tf
@@ -65,6 +65,8 @@ resource "aws_subnet" "salvo-infra-control-vm-subnet" {
   vpc_id     = aws_vpc.salvo-infra-vpc.id
   cidr_block = "192.168.4.0/22"
 
+  map_public_ip_on_launch = true
+
   tags = {
     Name    = "salvo-infra-control-vm-subnet"
     Project = "Salvo"


### PR DESCRIPTION
- run scripts were not copied to the VM image, fixing.
- the `/home/ubuntu/scripts/` did not exist, creating it explicitly.
- running the install script under `bash`.
- installing `jq` which is needed by the run script.
- installing `git` and `inotify-tools` that are needed by the AZP agent.
- correcting location of the run script, since Salvo keeps it in `/home/ubuntu/scripts/`.
- setting regions to the Salvo's region `us-west-1`.
- setting `update_default_version` in launch template, so that each new version becomes the default version.
- assigning public IP to control VMs for debugging.
- formatted Terraform and Packer files.