### PR TITLE
ami/build: Fixes for new build

### DIFF
--- a/ami-build/azp-build-arm64.pkr.hcl
+++ b/ami-build/azp-build-arm64.pkr.hcl
@@ -3,7 +3,7 @@
 
 source "amazon-ebs" "envoy-azp-build-arm64" {
   ami_name = "envoy-azp-build-arm64-{{timestamp}}"
-  instance_type = "r6g.large"
+  instance_type = "m6g.large"
   region = "us-east-2"
   security_group_ids = ["sg-030a7a75a086f208c"]
 

--- a/ami-build/scripts/run-fun.sh
+++ b/ami-build/scripts/run-fun.sh
@@ -110,7 +110,7 @@ azp_get_instance_id () {
 
 configure_bazel_remote () {
     # Set up and start a systemd unit for the bazel local cache.
-    local bazel_cache_bucket="$2" cache_prefix="$2" bazel_remote_args
+    local bazel_cache_bucket="$1" cache_prefix="$2" bazel_remote_args
     bazel_remote_args=(
         --experimental_remote_asset_api
         --enable_ac_key_instance_mangling

--- a/instances/azp-small-build-asg/iam.tf
+++ b/instances/azp-small-build-asg/iam.tf
@@ -9,6 +9,31 @@ data "aws_iam_policy_document" "asg_detach_small_instances" {
       "arn:aws:autoscaling:*:${var.aws_account_id}:autoScalingGroup:*:autoScalingGroupName/${local.asg_name}",
     ]
   }
+
+  statement {
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bazel_cache_bucket}",
+    ]
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "${var.cache_prefix}/*",
+      ]
+    }
+  }
+  statement {
+    actions = [
+      "s3:*Object"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bazel_cache_bucket}/${var.cache_prefix}/*",
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "small_instance_assume_role_policy" {


### PR DESCRIPTION
- fix bucket arg
- fix arm build vm (current is not available for base ami)
- add bucket creds for small arm instances

Fix #17