### PR TITLE
ami/build: Add `btop` to VMs

### DIFF
--- a/ami-build/scripts/install-fun.sh
+++ b/ami-build/scripts/install-fun.sh
@@ -21,6 +21,7 @@ AGENT_FILE="vsts-agent-linux-${ARCH}-${AGENT_VERSION}"
 AGENT_DL_URL="https://vstsagentpackage.azureedge.net/agent/${AGENT_VERSION}/${AGENT_FILE}.tar.gz"
 APT_PKGS_AGENT=(
     awscli
+    btop
     git
     inotify-tools
     jq)


### PR DESCRIPTION
this is an incredibly useful tool for monitoring a VM - i find myself installing it on every login