### PR TITLE
ami/build: Add `emacs` and `byobu`

### DIFF
--- a/ami-build/scripts/install-fun.sh
+++ b/ami-build/scripts/install-fun.sh
@@ -22,6 +22,8 @@ AGENT_DL_URL="https://vstsagentpackage.azureedge.net/agent/${AGENT_VERSION}/${AG
 APT_PKGS_AGENT=(
     awscli
     btop
+    byobu
+    emacs-nox
     git
     inotify-tools
     jq)


### PR DESCRIPTION
The minimal image has less default software installed